### PR TITLE
730 feat allow non destructive confirm modals to accept reactnode descriptions

### DIFF
--- a/docs/app/data/categories.react.json
+++ b/docs/app/data/categories.react.json
@@ -25,7 +25,7 @@
     "name": "Containment",
     "description": "Components that contain other components.",
     "items": ["Confirm Modal", "Prompt Modal", "CTA Modal", "Modal", "Table"],
-    "next": [],
+    "next": ["Confirm Modal"],
     "new": ["CTA Modal"]
   },
   "navigation": {

--- a/docs/app/react/confirm-modal/components/confirm-modal-features.tsx
+++ b/docs/app/react/confirm-modal/components/confirm-modal-features.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Button, Show, useConfirmModal } from '@cerberus-design/react'
+import { css } from '@cerberus/styled-system/css'
 import { hstack } from '@cerberus/styled-system/patterns'
 import { useCallback, useState } from 'react'
 
@@ -13,8 +14,21 @@ export function NonDestructiveFeature() {
   const handleClick = useCallback(async () => {
     const userConsent = await confirm.show({
       heading: 'Add new payment method?',
-      description:
-        'This will add a new payment method to your account to be billed for future purchases.',
+      description: (
+        <>
+          This will add a new payment method to your account to be billed for
+          future purchases.{' '}
+          <a
+            className={css({
+              textStyle: 'link',
+            })}
+            href="#"
+          >
+            Learn more
+          </a>
+          .
+        </>
+      ),
       actionText: 'Yes, add payment method',
       cancelText: NOPE,
     })

--- a/docs/app/react/confirm-modal/dev.mdx
+++ b/docs/app/react/confirm-modal/dev.mdx
@@ -22,28 +22,42 @@ import { ConfirmModal, useConfirmModal } from '@cerberus/react'
 ### Non-destructive
 
 <CodePreview preview={<NonDestructivePreview />}>
-```tsx title="some-page.tsx"
+```tsx title="some-feature.tsx"
 import { ConfirmModal, useConfirmModal } from '@cerberus/react'
 
 function SomeFeature() {
   const confirm = useConfirmModal()
 
-  const handleConfirm = useCallback(async () => {
-    const consent = await confirm.show({
+  const handleClick = useCallback(async () => {
+    const userConsent = await confirm.show({
       heading: 'Add new payment method?',
-      description:
-        'This will add a new payment method to your account to be billed for future purchases.',
+      description: (
+        <>
+          This will add a new payment method to your account to be billed for
+          future purchases.{' '}
+          <a
+            className={css({
+              textStyle: 'link',
+            })}
+            href="#"
+          >
+            Learn more
+          </a>
+          .
+        </>
+      ),
       actionText: 'Yes, add payment method',
-      cancelText: 'No, cancel',
+      cancelText: NOPE,
     })
-    // do something with consent
-  }, [])
+    setConsent(userConsent)
+  }, [confirm])
 
   return (
     <Button onClick={handleConfirm}>Confirm</Button>
   )
 }
-
+```
+```tsx title="some-page.tsx" {8}
 function SomePage() {
   return(
     <ConfirmModal>
@@ -96,8 +110,12 @@ For customizing the Confirm Modal, we recommend extending the `confirmModal` slo
 ## API
 
 ```ts showLineNumbers=false
+export type ShowConfirmModalOptions =
+  | NonDestructiveConfirmModalOptions
+  | DestructiveConfirmOptions
+
 export interface ConfirmModalProviderValue {
-  show: (options: ConfirmModalOptions) => Promise<boolean>
+  show: (options: ShowConfirmModalOptions) => Promise<boolean>
 }
 
 define function ConfirmModal(props: PropsWithChildren<{}>): ReactNode
@@ -110,7 +128,7 @@ The `show` method accepts the following options:
 | Name     | Default | Description                            |
 | -------- | ------- | -------------------------------------- |
 | kind | `non-destructive` | The variant used to theme the modal.           |
-| heading | `''` | The heading of the modal. |
-| description | `''` | The description of the modal. |
-| actionText | `''` | The text for the action button. |
-| cancelText | `''` | The text for the cancel button. |
+| heading |  | The heading of the modal. |
+| description |  | The description of the modal. For non-destructive modals only, can be a ReactNode. |
+| actionText |  | The text for the action button. |
+| cancelText |  | The text for the cancel button. |

--- a/packages/panda-preset/src/recipes/slots/modal.ts
+++ b/packages/panda-preset/src/recipes/slots/modal.ts
@@ -20,7 +20,7 @@ export const modal: Partial<SlotRecipeConfig> = defineSlotRecipe({
   base: {
     dialog: {
       ...modalBase,
-      p: '8',
+      p: 'xl',
       userSelect: 'none',
       md: {
         w: '35.25rem',

--- a/packages/react/src/components/ModalHeader.tsx
+++ b/packages/react/src/components/ModalHeader.tsx
@@ -30,7 +30,6 @@ export function ModalHeader(props: ModalHeaderProps) {
         vstack({
           alignItems: 'flex-start',
           gap: 'md',
-          mb: 'md',
           position: 'relative',
         }),
       )}

--- a/packages/react/src/context/cta-modal.tsx
+++ b/packages/react/src/context/cta-modal.tsx
@@ -155,46 +155,46 @@ export function CTAModal(props: PropsWithChildren<CTAModalProviderProps>) {
             </IconButton>
           </span>
 
-          <ModalHeader>
-            <HStack justify="center" w="full">
-              <Avatar
-                ariaLabel=""
-                gradient="charon-light"
-                icon={
-                  <Show
-                    when={Boolean(confirmIcon)}
-                    fallback={<FallbackIcon size={24} />}
-                  >
-                    {confirmIcon}
-                  </Show>
-                }
-                src=""
-              />
-            </HStack>
-            <VStack gap="lg" w="full">
-              <ModalHeading>{content?.heading}</ModalHeading>
-              <ModalDescription>{content?.description}</ModalDescription>
-            </VStack>
-          </ModalHeader>
+          <VStack gap="xl" w="full">
+            <ModalHeader>
+              <VStack gap="lg" w="full">
+                <Avatar
+                  ariaLabel=""
+                  gradient="charon-light"
+                  icon={
+                    <Show
+                      when={Boolean(confirmIcon)}
+                      fallback={<FallbackIcon size={24} />}
+                    >
+                      {confirmIcon}
+                    </Show>
+                  }
+                  src=""
+                />
+                <ModalHeading>{content?.heading}</ModalHeading>
+                <ModalDescription>{content?.description}</ModalDescription>
+              </VStack>
+            </ModalHeader>
 
-          <HStack gap="md" pt="sm" w="full">
-            <Show when={Boolean(content?.actions?.length)}>
-              {content?.actions?.map((action, index) => (
-                <Button
-                  data-index={index}
-                  className={css({
-                    w: '1/2',
-                  })}
-                  key={index}
-                  onClick={handleActionClick}
-                  shape="rounded"
-                  usage="outlined"
-                >
-                  {action.text}
-                </Button>
-              ))}
-            </Show>
-          </HStack>
+            <HStack gap="md" w="full">
+              <Show when={Boolean(content?.actions?.length)}>
+                {content?.actions?.map((action, index) => (
+                  <Button
+                    data-index={index}
+                    className={css({
+                      w: '1/2',
+                    })}
+                    key={index}
+                    onClick={handleActionClick}
+                    shape="rounded"
+                    usage="outlined"
+                  >
+                    {action.text}
+                  </Button>
+                ))}
+              </Show>
+            </HStack>
+          </VStack>
         </Modal>
       </Portal>
     </CTAModalContext.Provider>

--- a/tests/panda-preset/recipes/slots/modal.test.ts
+++ b/tests/panda-preset/recipes/slots/modal.test.ts
@@ -30,7 +30,8 @@ describe('modal recipe', () => {
         opacity: '1',
       },
       opacity: '0',
-      p: '8',
+      p: 'xl',
+      userSelect: 'none',
       md: {
         w: '35.25rem',
       },


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #730 
<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
- Updates ConfirmModal show types to be more strict
- Allows ReactNode for non-destructive descriptions

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
