### PR TITLE
expandHeight and expandWidth animations should allow dynamic sizing o…

### DIFF
--- a/docs/app/react/accordion/components/dynamic-accordion.tsx
+++ b/docs/app/react/accordion/components/dynamic-accordion.tsx
@@ -1,0 +1,28 @@
+import {
+    AccordionItemGroup,
+    Accordion,
+  } from '@cerberus-design/react'
+import { Box } from '@cerberus-design/styled-system/jsx'
+
+export async function DynamicAccordion() {
+return (
+    <Box w="2/3">
+    <Accordion>
+        <AccordionItemGroup
+            heading="Dynamic Accordion"
+            value="dynamic-example"
+        >           
+            <Accordion>
+            <AccordionItemGroup
+                heading="Dynamic content"
+                value="dynamic-content"
+                size="sm"
+            >
+                An accordion can change size based on the content inside of it. This is a dynamic example.
+            </AccordionItemGroup>
+            </Accordion>
+        </AccordionItemGroup>
+    </Accordion>
+    </Box>
+)
+}

--- a/docs/app/react/accordion/overview.mdx
+++ b/docs/app/react/accordion/overview.mdx
@@ -7,6 +7,7 @@ a11y: 'touch-target'
 import CodePreview from '@/app/components/CodePreview'
 import OverviewList from '@/app/components/OverviewList'
 import DripDivider from '@/app/components/drip-divider'
+import { DynamicAccordion } from './components/dynamic-accordion'
 import { StaticPreview } from './components/static-preview'
 import { LivePlayground } from './components/live-playground'
 
@@ -21,6 +22,10 @@ import { LivePlayground } from './components/live-playground'
 
 <CodePreview preview={<StaticPreview />} />
 <LivePlayground />
+
+## Dynamic Content Example
+
+<CodePreview preview={<DynamicAccordion />} />
 
 <DripDivider />
 

--- a/packages/panda-preset/src/theme/keyframes.ts
+++ b/packages/panda-preset/src/theme/keyframes.ts
@@ -24,16 +24,18 @@ export const keyframes: CssKeyframes = defineKeyframes({
 
   // collapse
   expandHeight: {
-    from: { height: '0' },
-    to: { height: 'var(--height)' },
+    '0%': { height: '0' },
+    '99%': { height: 'var(--height)' },
+    '100%': { height: 'auto' },
   },
   collapseHeight: {
     from: { height: 'var(--height)' },
     to: { height: '0' },
   },
   expandWidth: {
-    from: { width: '0' },
-    to: { width: 'var(--width)' },
+    '0%': { width: '0' },
+    '99%': { width: 'var(--width)' },
+    '100%': { width: 'auto' },
   },
   collapseWidth: {
     from: { width: 'var(--width)' },

--- a/tests/panda-preset/theme/keyframes.test.ts
+++ b/tests/panda-preset/theme/keyframes.test.ts
@@ -26,8 +26,9 @@ describe('keyframes', () => {
 
   test('should export expandHeight', () => {
     expect(keyframes.expandHeight).toBeDefined()
-    expect(keyframes.expandHeight.from).toEqual({ height: '0' })
-    expect(keyframes.expandHeight.to).toEqual({ height: 'var(--height)' })
+    expect(keyframes.expandHeight['0%']).toEqual({ height: '0' })
+    expect(keyframes.expandHeight['99%']).toEqual({ height: 'var(--height)' })
+    expect(keyframes.expandHeight['100%']).toEqual({ height: 'auto' })
   })
 
   test('should export collapseHeight', () => {
@@ -38,8 +39,9 @@ describe('keyframes', () => {
 
   test('should export expandWidth', () => {
     expect(keyframes.expandWidth).toBeDefined()
-    expect(keyframes.expandWidth.from).toEqual({ width: '0' })
-    expect(keyframes.expandWidth.to).toEqual({ width: 'var(--width)' })
+    expect(keyframes.expandWidth['0%']).toEqual({ width: '0' })
+    expect(keyframes.expandWidth['99%']).toEqual({ width: 'var(--width)' })
+    expect(keyframes.expandWidth['100%']).toEqual({ width: 'auto' })
   })
 
   test('should export collapseWidth', () => {


### PR DESCRIPTION
…f target

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?

<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

Currently if a component uses the expandHeight or expandWidth animations the height or width of the component will be locked to the initial value on first render.  This means that any changes to the size of the target will be ignored.

## What is the new behavior (required)?

The keyframes have been updated to allow the size of the animation target to change size after the animation has played.

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
