### PR TITLE
fix(button): prevent hover styles when button is disabled

### DIFF
--- a/packages/panda-preset/src/recipes/shared/button.base.ts
+++ b/packages/panda-preset/src/recipes/shared/button.base.ts
@@ -74,6 +74,9 @@ export const textUsage = {
     _active: {
       color: textInitial,
     },
+    _hover: {
+      bgColor: 'transparent',
+    },
   },
 }
 
@@ -96,6 +99,11 @@ export const outlinedUsage = {
   bgColor: 'colorPalette.ghost.initial',
   border: '2px solid',
   borderColor: 'colorPalette.border.initial',
+  _disabled: {
+    _hover: {
+      bgColor: 'colorPalette.ghost.initial',
+    },
+  },
 }
 
 export const notifyStyles = {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?

When hovering over a disabled button, the background color changes unexpectedly for outlined and ghost variants only:
- Background color changes on hover despite being in a disabled state
- This behavior contradicts standard UX patterns where disabled elements should not show interactive states
- Creates potential user confusion about the element's interactivity

A video demonstration of this issue is attached below for reference.

| outlined | ghost |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/48581e09-461e-4530-be17-17b728cbb631" > | <video src="https://github.com/user-attachments/assets/4c5ec8a9-868e-4fe2-8a3f-3477d0913096" > |


<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?

Disabled buttons now maintain a consistent appearance when hovered:
- Background color remains unchanged on hover
- Follows WCAG best practices for disabled states
- Provides clear visual feedback that the element is non-interactive

The attached video demonstrates the improved behavior where disabled buttons no longer show hover effects.

| outlined | ghost |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/62aab119-fe92-4a72-973e-dec8f2b00f15" > | <video src="https://github.com/user-attachments/assets/121f5d42-1bf7-4e56-84ea-3a8897109e97" > |

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
