### PR TITLE
fix(preset): add missing zIndex to positioners for menu & combobox

### DIFF
--- a/packages/panda-preset/src/recipes/slots/combobox.ts
+++ b/packages/panda-preset/src/recipes/slots/combobox.ts
@@ -133,6 +133,7 @@ export const combobox: Partial<SlotRecipeConfig> = defineSlotRecipe({
     },
     positioner: {
       w: 'var(--reference-width)',
+      zIndex: 'dropdown!',
     },
     content: {
       bgColor: 'page.surface.100',

--- a/packages/panda-preset/src/recipes/slots/menu.ts
+++ b/packages/panda-preset/src/recipes/slots/menu.ts
@@ -17,8 +17,10 @@ export const menu: Partial<SlotRecipeConfig> = defineSlotRecipe({
   slots: menuAnatomy.keys(),
 
   base: {
+    positioner: {
+      zIndex: 'dropdown!',
+    },
     content: {
-      '--menu-z-index': 'zIndex.popover',
       bgColor: 'page.surface.100',
       border: '1px solid',
       borderColor: 'page.border.200',
@@ -30,7 +32,6 @@ export const menu: Partial<SlotRecipeConfig> = defineSlotRecipe({
       minW: '10rem',
       rounded: 'md',
       shadow: 'lg',
-      zIndex: 'calc(var(--menu-z-index) + var(--layer-index, 0))',
       ...focusStates,
       _open: {
         animationStyle: 'slide-fade-in',

--- a/packages/react/src/components/menu/primitives.ts
+++ b/packages/react/src/components/menu/primitives.ts
@@ -48,7 +48,7 @@ export const MenuIndicator = withNoRecipe(ArkMenu.Indicator)
 // Positioner
 
 export type MenuPositionerProps = CerberusPrimitiveProps<ArkMenuPositionerProps>
-export const MenuPositioner = withNoRecipe(ArkMenu.Positioner)
+export const MenuPositioner = withSlotRecipe(ArkMenu.Positioner, 'positioner')
 
 // Content
 

--- a/tests/panda-preset/recipes/slots/combobox.test.ts
+++ b/tests/panda-preset/recipes/slots/combobox.test.ts
@@ -168,6 +168,7 @@ describe('combobox recipe', () => {
   test('should have base.positioner styles', () => {
     expect(combobox.base?.positioner).toMatchObject({
       w: 'var(--reference-width)',
+      zIndex: 'dropdown!',
     })
   })
 

--- a/tests/panda-preset/recipes/slots/menu.test.ts
+++ b/tests/panda-preset/recipes/slots/menu.test.ts
@@ -8,9 +8,14 @@ describe('menu recipe', () => {
     expect(menu).toBeDefined()
   })
 
+  test('should have a positioner style', () => {
+    expect(menu.base?.positioner).toMatchObject({
+      zIndex: 'dropdown!',
+    })
+  })
+
   test('should have a base style', () => {
     expect(menu.base?.content).toMatchObject({
-      '--menu-z-index': 'zIndex.popover',
       bgColor: 'page.surface.100',
       border: '1px solid',
       borderColor: 'page.border.200',
@@ -20,7 +25,6 @@ describe('menu recipe', () => {
       minW: '10rem',
       rounded: 'md',
       shadow: 'lg',
-      zIndex: 'calc(var(--menu-z-index) + var(--layer-index, 0))',
       _open: {
         animationStyle: 'slide-fade-in',
         animationDuration: 'fast',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #1691 
<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
Adds missing zIndex properties to menu-related positioners

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
