### PR TITLE
fix(preset): add missing positioner styles to datePicker recipe

### DIFF
--- a/packages/panda-preset/src/recipes/slots/datepicker.ts
+++ b/packages/panda-preset/src/recipes/slots/datepicker.ts
@@ -47,6 +47,9 @@ export const datePicker: Partial<SlotRecipeConfig> = defineSlotRecipe({
         color: 'page.text.100',
       },
     },
+    positioner: {
+      zIndex: 'dropdown!',
+    },
     control: {
       alignItems: 'center',
       display: 'flex',

--- a/packages/react/src/components/date-picker/primitives.tsx
+++ b/packages/react/src/components/date-picker/primitives.tsx
@@ -150,7 +150,10 @@ export const DatePickerClearTrigger = withNoRecipe(DatePicker.ClearTrigger)
  */
 export type DatePickerPositionerProps =
   CerberusPrimitiveProps<ArkDatePickerPositionerProps>
-export const DatePickerPositioner = withNoRecipe(DatePicker.Positioner)
+export const DatePickerPositioner = withSlotRecipe(
+  DatePicker.Positioner,
+  'positioner',
+)
 
 /**
  * The year select input component of the DatePicker. This primitive has no

--- a/tests/panda-preset/recipes/slots/datePicker.test.ts
+++ b/tests/panda-preset/recipes/slots/datePicker.test.ts
@@ -38,6 +38,12 @@ describe('datePicker recipe', () => {
     })
   })
 
+  test('should have a positioner style', () => {
+    expect(datePicker.base?.positioner).toMatchObject({
+      zIndex: 'dropdown!',
+    })
+  })
+
   test('should have an input style', () => {
     expect(datePicker.base?.input).toMatchObject({
       bgColor: 'page.surface.initial',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #1863 
<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
Adds missing `positioner` styles to date picker recipe

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
