### PR TITLE
fix(react): remove deprecated forwardRef from primitve factor

### DIFF
--- a/docs/app/docs/components/[slug]/components/progress/circular.tsx
+++ b/docs/app/docs/components/[slug]/components/progress/circular.tsx
@@ -14,12 +14,7 @@ function NotStartedText() {
 export function CircularPreview() {
   return (
     <HStack>
-      <CircularProgress
-        id="0"
-        defaultValue={0}
-        label={<NotStartedText />}
-        hideValueText
-      />
+      <CircularProgress id="0" defaultValue={0} label={<NotStartedText />} hideValueText />
       <CircularProgress id="25" defaultValue={25} />
       <CircularProgress id="50" defaultValue={50} />
       <CircularProgress id="75" defaultValue={75} />
@@ -34,12 +29,7 @@ export function SizesPreview() {
       <CircularProgress id="25" defaultValue={25} size="xs" />
       <CircularProgress id="50" defaultValue={50} size="sm" />
       <CircularProgress id="75" defaultValue={75} size="md" />
-      <CircularProgress
-        id="complete"
-        label="complete"
-        defaultValue={100}
-        size="lg"
-      />
+      <CircularProgress id="complete" label="complete" defaultValue={100} size="lg" />
     </HStack>
   )
 }
@@ -47,11 +37,7 @@ export function SizesPreview() {
 export function HideValueTextPreview() {
   return (
     <HStack justify="center" w="1/2">
-      <CircularProgress
-        defaultValue={0}
-        label={<NotStartedText />}
-        hideValueText
-      />
+      <CircularProgress defaultValue={0} label={<NotStartedText />} hideValueText />
     </HStack>
   )
 }

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -40,7 +40,7 @@ export function Button(props: ButtonProps) {
         {...nativeProps}
         data-scope="button"
         data-part="root"
-        disabled={pending || props.disabled}
+        disabled={pending || nativeProps.disabled}
       />
     </ButtonContext.Provider>
   )

--- a/packages/react/src/components/button/primitives.tsx
+++ b/packages/react/src/components/button/primitives.tsx
@@ -1,15 +1,12 @@
 import { ark } from '@ark-ui/react/factory'
-import type { HTMLAttributes } from 'react'
+import type { ButtonHTMLAttributes, HTMLAttributes } from 'react'
 import {
   button,
   buttonGroup,
   ButtonVariantProps,
   type ButtonGroupVariantProps,
 } from 'styled-system/recipes'
-import {
-  createCerberusPrimitive,
-  type CerberusPrimitiveProps,
-} from '../../system/index'
+import { createCerberusPrimitive, type CerberusPrimitiveProps } from '../../system/index'
 
 /**
  * This module contains the Button component primitives.
@@ -24,7 +21,7 @@ const { withRecipe: withGroupRecipe } = createCerberusPrimitive(buttonGroup)
  */
 export const ButtonRoot = withRecipe(ark.button)
 export type ButtonRootProps = CerberusPrimitiveProps<
-  HTMLAttributes<HTMLButtonElement> & ButtonVariantProps
+  ButtonHTMLAttributes<HTMLButtonElement> & ButtonVariantProps
 >
 
 const ButtonGroupEl = withGroupRecipe(ark.div)

--- a/packages/react/src/system/primitive-factory.tsx
+++ b/packages/react/src/system/primitive-factory.tsx
@@ -1,11 +1,8 @@
 import { ark } from '@ark-ui/react/factory'
-import { forwardRef, type ElementType } from 'react'
+import { type ElementType } from 'react'
 import { css, cx, type Styles } from 'styled-system/css'
 import { cerberus } from 'styled-system/jsx/factory'
-import type {
-  CerberusComponent,
-  RecipeVariantRecord,
-} from 'styled-system/types'
+import type { CerberusComponent, RecipeVariantRecord } from 'styled-system/types'
 import type { ExtractProps } from '../types'
 import type {
   CerberusPrimitiveEl,
@@ -82,40 +79,32 @@ export class CerberusPrimitive {
    * @returns A new React component that applies the recipe to the original
    * component.
    */
-  withRecipe = <T extends ElementType>(
-    Component: T,
-    options?: WithRecipeOptions,
-  ) => {
+  withRecipe = <T extends ElementType>(Component: T, options?: WithRecipeOptions) => {
     type Props = ExtractProps<T>
     const { defaultProps } = options || {}
     const El = this.setupStyledComponent<T>(Component)
 
     const recipe = this.recipe as CerberusRecipe
 
-    const CerbComponent = forwardRef<unknown, CerberusPrimitiveProps<Props>>(
-      (internalProps, ref) => {
-        const { css: customCss, ...restOfInternalProps } = internalProps
+    const CerbComponent = (internalProps: CerberusPrimitiveProps<Props>) => {
+      const { css: customCss, ref, ...restOfInternalProps } = internalProps
 
-        const [variantOptions, nativeProps] =
-          recipe.splitVariantProps(restOfInternalProps)
-        const recipeStyles = recipe(variantOptions)
+      const [variantOptions, nativeProps] = recipe.splitVariantProps(restOfInternalProps)
+      const recipeStyles = recipe(variantOptions)
 
-        // Safely access className
-        const className =
-          typeof nativeProps.className === 'string'
-            ? nativeProps.className
-            : undefined
+      // Safely access className
+      const className =
+        typeof nativeProps.className === 'string' ? nativeProps.className : undefined
 
-        return (
-          <El
-            {...defaultProps}
-            {...(nativeProps as Props)}
-            ref={ref}
-            className={cx(className, recipeStyles, css(customCss as Styles))}
-          />
-        )
-      },
-    )
+      return (
+        <El
+          {...defaultProps}
+          {...(nativeProps as Props)}
+          ref={ref}
+          className={cx(className, recipeStyles, css(customCss as Styles))}
+        />
+      )
+    }
 
     const ElName = typeof El === 'string' ? El : El.displayName || El.name
     CerbComponent.displayName = ElName
@@ -146,31 +135,26 @@ export class CerberusPrimitive {
 
     const recipe = this.recipe as CerberusSlotRecipe<typeof slot>
 
-    const CerbComponent = forwardRef<unknown, CerberusPrimitiveProps<Props>>(
-      (internalProps, ref) => {
-        const { css: customCss, ...restOfInternalProps } = internalProps
+    const CerbComponent = (internalProps: CerberusPrimitiveProps<Props>) => {
+      const { css: customCss, ref, ...restOfInternalProps } = internalProps
 
-        const [variantOptions, nativeProps] =
-          recipe.splitVariantProps(restOfInternalProps)
-        const styles = recipe(variantOptions)
-        const slotStyles = styles[slot as keyof typeof styles]
+      const [variantOptions, nativeProps] = recipe.splitVariantProps(restOfInternalProps)
+      const styles = recipe(variantOptions)
+      const slotStyles = styles[slot as keyof typeof styles]
 
-        // Safely access className
-        const className =
-          typeof nativeProps.className === 'string'
-            ? nativeProps.className
-            : undefined
+      // Safely access className
+      const className =
+        typeof nativeProps.className === 'string' ? nativeProps.className : undefined
 
-        return (
-          <El
-            {...defaultProps}
-            {...(nativeProps as Props)}
-            ref={ref}
-            className={cx(className, slotStyles, css(customCss as Styles))}
-          />
-        )
-      },
-    )
+      return (
+        <El
+          {...defaultProps}
+          {...(nativeProps as Props)}
+          ref={ref}
+          className={cx(className, slotStyles, css(customCss as Styles))}
+        />
+      )
+    }
 
     const ElName = typeof El === 'string' ? El : El.displayName || El.name
     CerbComponent.displayName = ElName

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9922,14 +9922,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.3(jiti@2.4.2))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.3(jiti@2.4.2)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.3(jiti@2.4.2))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.0.3(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@10.0.3(jiti@2.4.2))(typescript@5.9.3)
       eslint: 10.0.3(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.0.3(jiti@2.4.2))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@10.0.3(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9944,7 +9944,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.0.3(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.3(jiti@2.4.2))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.0.3(jiti@2.4.2))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@10.0.3(jiti@2.4.2))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.0.3(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #2078 
closes #2073 
<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
- Adding signals into React causes doc exceeds error from deps - need to add a peer in the future
- Removes `forwardRef` fn from factory which is no longer needed. Also causing too complex types for progress React APIs

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
