### PR TITLE
useStatefulCollection should ignore case and target label as well.

### DIFF
--- a/packages/react/src/components/combobox/use-stateful-collection.ts
+++ b/packages/react/src/components/combobox/use-stateful-collection.ts
@@ -45,8 +45,10 @@ export function useStatefulCollection(
         return setItems(initialItems)
       }
       setItems((prev) =>
-        prev.filter((item) =>
-          item.value.includes(details.inputValue.toLowerCase()),
+        prev.filter(
+          (item) =>
+            item.value.toLowerCase().includes(details.inputValue.toLowerCase()) ||
+            item.label.toLowerCase().includes(details.inputValue.toLowerCase()),
         ),
       )
       setFilterValue(details.inputValue.split(''))

--- a/tests/react/components/combobox.test.tsx
+++ b/tests/react/components/combobox.test.tsx
@@ -88,13 +88,13 @@ describe('Combobox', () => {
     expect(screen.getByText('🔥')).toBeInTheDocument()
   })
 
-  test('should return a stateful object for the root component', async () => {
+  test('should return a stateful object for the root component and filter', async () => {
     function Test() {
       const { collection, handleInputChange } = useStatefulCollection([
         { label: 'Hades', value: 'hades' },
         { label: 'Persephone', value: 'persephone' },
         { label: 'Zeus', value: 'zeus', disabled: true },
-        { label: 'Heracles', value: 'Hercules' },
+        { label: 'Heracles', value: 'half god' },
       ])
       return (
         <Combobox

--- a/tests/react/components/combobox.test.tsx
+++ b/tests/react/components/combobox.test.tsx
@@ -88,12 +88,13 @@ describe('Combobox', () => {
     expect(screen.getByText('🔥')).toBeInTheDocument()
   })
 
-  test('should return a stateful object for the root component', () => {
+  test('should return a stateful object for the root component', async () => {
     function Test() {
       const { collection, handleInputChange } = useStatefulCollection([
         { label: 'Hades', value: 'hades' },
         { label: 'Persephone', value: 'persephone' },
         { label: 'Zeus', value: 'zeus', disabled: true },
+        { label: 'Heracles', value: 'Hercules' },
       ])
       return (
         <Combobox
@@ -120,5 +121,7 @@ describe('Combobox', () => {
     )
     expect(screen.getByRole('combobox')).toBeInTheDocument()
     expect(screen.getByText(/select relative/i)).toBeInTheDocument()
+    await userEvent.type(screen.getByRole('combobox'), 'her')
+    expect(screen.getByText(/Heracles/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?

The ComboBox's useStatefulCollection hook only supports filtering collections with all lower case values.

## What is the new behavior (required)?

useStatefulCollection has been updated to filter on the value or the label and lowers both the target and the input to ensure expected matches.
