### PR TITLE
chore(react): remove deprecated toaster.notify APIs breaks Jest from Ark

### DIFF
--- a/docs/app/docs/components/[slug]/components/notifications/messages.data.json
+++ b/docs/app/docs/components/[slug]/components/notifications/messages.data.json
@@ -18,7 +18,7 @@
     "description": "Please check your connection."
   },
   "danger": {
-    "type": "danger",
+    "type": "error",
     "title": "Unable to Update",
     "description": "An error occurred. Please try again."
   },

--- a/docs/app/docs/components/[slug]/components/notifications/subtle.data.json
+++ b/docs/app/docs/components/[slug]/components/notifications/subtle.data.json
@@ -1,6 +1,7 @@
 {
   "infoSubtle": {
-    "type": "info-subtle",
+    "type": "info",
+    "usage": "subtle",
     "title": "Update Available",
     "description": "A new version of the app is available.",
     "action": {
@@ -8,23 +9,27 @@
     }
   },
   "successSubtle": {
-    "type": "success-subtle",
+    "type": "success",
     "title": "Profile Updated",
+    "usage": "subtle",
     "description": "Your profile has been updated."
   },
   "warningSubtle": {
-    "type": "warning-subtle",
+    "type": "warning",
     "title": "Slow Network",
+    "usage": "subtle",
     "description": "Please check your connection."
   },
   "dangerSubtle": {
-    "type": "danger-subtle",
+    "type": "error",
     "title": "Unable to Update",
+    "usage": "subtle",
     "description": "An error occurred. Please try again."
   },
   "loadingSubtle": {
-    "type": "loading-subtle",
+    "type": "loading",
     "title": "Loading",
+    "usage": "subtle",
     "description": "It's taking longer than normal."
   }
 }

--- a/docs/app/docs/components/[slug]/content/notifications.mdx
+++ b/docs/app/docs/components/[slug]/content/notifications.mdx
@@ -8,13 +8,11 @@ ark: 'toast'
 ---
 
 import CodePreview from '@/app/components/CodePreview'
-import {
-  NoteAdmonition,
-} from '@/app/components/Admonition'
+import { NoteAdmonition } from '@/app/components/Admonition'
 import {
   CustomConfigDemo,
   OverviewDemo,
-  SubtleDemo
+  SubtleDemo,
 } from '../components/notifications/static'
 import { NotifyBadgePreview } from '../components/notifications/notify-badge'
 
@@ -33,23 +31,24 @@ The `NotificationCenter` component is used to manage notifications in your appli
 import { toaster } from '@cerberus/react'
 
 function Feature() {
-  const handleClick = useCallback(() => {
-    toaster.create({
-      type: 'info',
-      title: 'Update Available',
-      description: 'A new version of the app is available',
-      action: {
-        label: 'Refresh',
-        onClick: () => {
-          window.location.reload()
-        }
-      }
-    })
-  }, [])
-
-  return <Button onClick={handleClick}>Trigger notification</Button>
+const handleClick = useCallback(() => {
+toaster.create({
+type: 'info',
+title: 'Update Available',
+description: 'A new version of the app is available',
+action: {
+label: 'Refresh',
+onClick: () => {
+window.location.reload()
 }
-```
+}
+})
+}, [])
+
+return <Button onClick={handleClick}>Trigger notification</Button>
+}
+
+````
 ```tsx title="layout.tsx"
 import { NotificationCenter } from '@cerberus/react'
 
@@ -61,7 +60,8 @@ export function Layout(props: PropsWithChildren<{}>) {
     </>
   )
 }
-```
+````
+
 </CodePreview>
 
 ### Types
@@ -75,24 +75,25 @@ Just update the `options.types` to change the theme of the notification. The opt
 import { toaster } from '@cerberus/react'
 
 function Feature() {
-  const handleClick = useCallback(() => {
-    toaster.create({
-      type: 'loading',
-      title: 'Loading',
-      description: 'It's taking longer than normal.',
-    })
-  }, [toaster.create])
+const handleClick = useCallback(() => {
+toaster.create({
+type: 'loading',
+title: 'Loading',
+description: 'It's taking longer than normal.',
+})
+}, [toaster.create])
 
-  return <Button onClick={handleClick}>Trigger notification</Button>
+return <Button onClick={handleClick}>Trigger notification</Button>
 }
-```
+
+````
 </CodePreview>
 
 ## Subtle Notifications
 
 Subtle notifications are a less intrusive way to inform users about events or updates. They typically have a softer appearance and may not require immediate user action.
 
-Use the `-subtle` suffix with the notification type to create a subtle notification.
+Use the `usage: 'subtle'` option to create a subtle notification.
 
 <CodePreview preview={<SubtleDemo />}>
 ```tsx title="Subtle Notifications Demo"
@@ -103,7 +104,8 @@ import { toaster } from '@cerberus/react'
 function Feature() {
   const handleClick = useCallback(() => {
     toaster.create({
-      type: 'info-subtle',
+      type: 'info',
+      usage: 'subtle',
       title: 'Update Available',
       description: 'A new version of the app is available',
       action: {
@@ -117,7 +119,8 @@ function Feature() {
 
   return <Button onClick={handleClick}>Trigger subtle notification</Button>
 }
-```
+````
+
 </CodePreview>
 
 ## Custom Configuration
@@ -134,34 +137,36 @@ import { createToaster, NotificationCenter, Button } from '@cerberus/react'
 import { HStack } from 'styled-system/jsx'
 
 function CustomConfigDemo() {
-  const customToaster = createToaster({
-    gap: 24,
-    overlap: false,
-    placement: 'bottom-end',
-  })
+const customToaster = createToaster({
+gap: 24,
+overlap: false,
+placement: 'bottom-end',
+})
 
-  return (
-    <>
-      <HStack>
-        <Button
-          onClick={() => {
-            customToaster.create({
-              title: 'Custom Toaster',
-              description:
-                'This notification is using a custom toaster configuration.',
-              type: 'success',
-            })
-          }}
-        >
-          Show Notification
-        </Button>
-      </HStack>
+return (
+
+<>
+<HStack>
+<Button
+onClick={() => {
+customToaster.create({
+title: 'Custom Toaster',
+description:
+'This notification is using a custom toaster configuration.',
+type: 'success',
+})
+}} >
+Show Notification
+</Button>
+</HStack>
 
       <NotificationCenter toaster={customToaster} />
     </>
-  )
+
+)
 }
-```
+
+````
 </CodePreview>
 
 ## Badges
@@ -186,22 +191,22 @@ export function NotifyBadgePreview() {
   </IconButton>
   )
 }
-```
-</CodePreview>
+````
 
+</CodePreview>
 
 ## Primitives
 
 You can utilize the primitive components to customize the toast notification.
 
-| Component | Description |
-| --------- | ----------- |
-| NotificationProvider    | The context provider for the toast notifications. |
-| NotificationRoot | The context provider for the toast parts. |
-| NotificationHeading | The title heading of the toast. |
-| NotificationDescription | The description of the toast. |
-| NotificationCloseTrigger | The close button of the toast. |
-| NotificationActionTrigger | The action button of the toast. |
+| Component                 | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| NotificationProvider      | The context provider for the toast notifications. |
+| NotificationRoot          | The context provider for the toast parts.         |
+| NotificationHeading       | The title heading of the toast.                   |
+| NotificationDescription   | The description of the toast.                     |
+| NotificationCloseTrigger  | The close button of the toast.                    |
+| NotificationActionTrigger | The action button of the toast.                   |
 
 ## API
 
@@ -213,23 +218,24 @@ The `NotificationCenter` component is an abstraction of the primitives and doesn
 
 The `toaster` object is used to create notifications and accepts the following options:
 
-| Name     | Type     | Description                            |
-| -------- | -------- | -------------------------------------- |
-| type     | string   | The type of notification. Options are `info`, `success`, `warning`, `error`, and `loading`. |
-| title    | string   | The title of the notification. |
-| description | string | The description of the notification. |
-| action   | `ToasterAction`   | The action object of the notification. |
-| duration | number   | A custom duration of the notification. |
-| onClose  | function | The callback function when the notification is closed. |
+| Name        | Type                    | Description                                                                                 |
+| ----------- | ----------------------- | ------------------------------------------------------------------------------------------- |
+| type        | string                  | The type of notification. Options are `info`, `success`, `warning`, `error`, and `loading`. |
+| title       | string                  | The title of the notification.                                                              |
+| description | string                  | The description of the notification.                                                        |
+| action      | `ToasterAction`         | The action object of the notification.                                                      |
+| duration    | number                  | A custom duration of the notification.                                                      |
+| onClose     | function                | The callback function when the notification is closed.                                      |
+| usage       | `'subtle' \| 'default'` | The visual type of the notification. The default option is `default`.                       |
 
 ### `ToasterAction`
 
 The `ToasterAction` object is used to create an action button for the notification and accepts the following options:
 
-| Name     | Type     | Description                            |
-| -------- | -------- | -------------------------------------- |
-| label    | string   | The label of the action button. |
-| onClick  | function | The callback function when the action button is clicked. |
+| Name    | Type     | Description                                              |
+| ------- | -------- | -------------------------------------------------------- |
+| label   | string   | The label of the action button.                          |
+| onClick | function | The callback function when the action button is clicked. |
 
 ### Parts
 
@@ -237,10 +243,10 @@ The `NotificationParts` API is an Object containing the full family of component
 
 <NoteAdmonition description="It is best to only use the NotificationParts if you are building a custom solution. Importing Object based components will ship every property it includes into your bundle, regardless if you use it or not." />
 
-| Name     | Description                            |
-| -------- | -------------------------------------- |
-| Root     | The `NotificationRoot` component which is the Provider for the toast. |
-| Heading     | The `NotificationHeading` component which displays the heading title for the toast. |
-| Description     | The `NotificationDescription` component which displays the description for the toast. |
-| CloseTrigger     | The `NotificationCloseTrigger` component which displays the close button for the toast. |
-| ActionTrigger     | The `NotificationActionTrigger` component which displays the action button for the toast. |
+| Name          | Description                                                                               |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| Root          | The `NotificationRoot` component which is the Provider for the toast.                     |
+| Heading       | The `NotificationHeading` component which displays the heading title for the toast.       |
+| Description   | The `NotificationDescription` component which displays the description for the toast.     |
+| CloseTrigger  | The `NotificationCloseTrigger` component which displays the close button for the toast.   |
+| ActionTrigger | The `NotificationActionTrigger` component which displays the action button for the toast. |

--- a/packages/react/src/components/notifications/center.tsx
+++ b/packages/react/src/components/notifications/center.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Toaster, type CreateToasterReturn } from '@ark-ui/react/toast'
+import { useMemo } from 'react'
 import { Box } from 'styled-system/jsx'
 import { Button, type ButtonProps } from '../button/button'
 import { Show } from '../show/index'
@@ -8,15 +9,16 @@ import { ToastCloseTrigger } from './close-trigger'
 import { MatchNotificationIcon } from './match-icon'
 import { NotificationParts } from './parts'
 import { toaster } from './toaster'
-import type { NotifyOptions, NotifyOptionsType } from './types'
+import type { NotifyOptions } from './types'
 
 /**
  * This module contains an abstraction of the Notification parts.
  * @module 'notification/center'
  */
 
-export function getEmphasis(type: NotifyOptionsType) {
-  return type.includes('subtle') ? 'low' : 'high'
+export function getEmphasis(options: NotifyOptions) {
+  if (options.usage === 'subtle') return 'low'
+  return 'high'
 }
 
 export interface NotificationCenterProps {
@@ -28,16 +30,13 @@ export interface NotificationCenterProps {
  * component. It manages displaying all the toasts in the center.
  */
 export function NotificationCenter(props: NotificationCenterProps) {
-  const cachedToaster = props.toaster || toaster
+  const cachedToaster = useMemo(() => props.toaster || toaster, [props.toaster])
 
   return (
     <Toaster toaster={cachedToaster}>
       {(toast) => (
-        <NotificationParts.Root
-          key={toast.id}
-          data-emphasis={getEmphasis((toast.type ?? 'info') as NotifyOptionsType)}
-        >
-          <MatchNotificationIcon type={toast.type as NotifyOptions['palette']} />
+        <NotificationParts.Root key={toast.id} data-emphasis={getEmphasis(toast)}>
+          <MatchNotificationIcon type={toast.type} />
 
           <Box flex="1" paddingBlock="sm">
             <NotificationParts.Heading>{toast.title}</NotificationParts.Heading>

--- a/packages/react/src/components/notifications/center.tsx
+++ b/packages/react/src/components/notifications/center.tsx
@@ -4,15 +4,11 @@ import { Toaster, type CreateToasterReturn } from '@ark-ui/react/toast'
 import { Box } from 'styled-system/jsx'
 import { Button, type ButtonProps } from '../button/button'
 import { Show } from '../show/index'
-import { NotificationParts } from './parts'
-import type {
-  NotifyOptions,
-  NotifyOptionsType,
-  UseNotificationCenterReturn,
-} from './types'
-import { MatchNotificationIcon } from './match-icon'
 import { ToastCloseTrigger } from './close-trigger'
+import { MatchNotificationIcon } from './match-icon'
+import { NotificationParts } from './parts'
 import { toaster } from './toaster'
+import type { NotifyOptions, NotifyOptionsType } from './types'
 
 /**
  * This module contains an abstraction of the Notification parts.
@@ -39,13 +35,9 @@ export function NotificationCenter(props: NotificationCenterProps) {
       {(toast) => (
         <NotificationParts.Root
           key={toast.id}
-          data-emphasis={getEmphasis(
-            (toast.type ?? 'info') as NotifyOptionsType,
-          )}
+          data-emphasis={getEmphasis((toast.type ?? 'info') as NotifyOptionsType)}
         >
-          <MatchNotificationIcon
-            type={toast.type as NotifyOptions['palette']}
-          />
+          <MatchNotificationIcon type={toast.type as NotifyOptions['palette']} />
 
           <Box flex="1" paddingBlock="sm">
             <NotificationParts.Heading>{toast.title}</NotificationParts.Heading>
@@ -70,19 +62,4 @@ export function NotificationCenter(props: NotificationCenterProps) {
       )}
     </Toaster>
   )
-}
-
-/**
- * @deprecated use `toaster` instead
- */
-export function useNotificationCenter(): UseNotificationCenterReturn {
-  function notify(options: NotifyOptions) {
-    toaster.create({
-      title: options.heading,
-      description: options.description,
-      type: options.palette,
-      action: options.action,
-    })
-  }
-  return { ...toaster, notify }
 }

--- a/packages/react/src/components/notifications/match-icon.tsx
+++ b/packages/react/src/components/notifications/match-icon.tsx
@@ -4,8 +4,8 @@ import { ark } from '@ark-ui/react/factory'
 import { toast } from 'styled-system/recipes'
 import { useCerberusContext } from '../../context/cerberus'
 import { Spinner } from '../spinner/index'
-import type { NotifyOptions, NotifyOptionsType } from './types'
 import { getEmphasis } from './center'
+import type { NotifyOptions } from './types'
 
 /**
  * This private module contains a component that returns the correct icon for a
@@ -14,11 +14,7 @@ import { getEmphasis } from './center'
  * @module 'notification/match-icon'
  */
 
-interface MatchNotificationIconProps {
-  type?: NotifyOptions['palette']
-}
-
-export function MatchNotificationIcon(props: MatchNotificationIconProps) {
+export function MatchNotificationIcon(props: NotifyOptions) {
   const { icons } = useCerberusContext()
   const type = props.type?.split('-')[0] || 'info'
   const styles = toast()
@@ -27,10 +23,7 @@ export function MatchNotificationIcon(props: MatchNotificationIconProps) {
   const Icon = icons[key] || ToastLoadingIcon
 
   return (
-    <ark.div
-      data-emphasis={getEmphasis(props.type as NotifyOptionsType)}
-      className={styles.icon}
-    >
+    <ark.div data-emphasis={getEmphasis(props)} className={styles.icon}>
       <Icon />
     </ark.div>
   )

--- a/packages/react/src/components/notifications/toaster.ts
+++ b/packages/react/src/components/notifications/toaster.ts
@@ -7,7 +7,3 @@ export const toaster: CreateToasterReturn = createToaster({
   overlap: true,
   placement: 'top-end',
 })
-
-// Re-exporting for easier customization
-
-export { createToaster, Toaster } from '@ark-ui/react/toast'

--- a/packages/react/src/components/notifications/types.ts
+++ b/packages/react/src/components/notifications/types.ts
@@ -1,36 +1,7 @@
-import type { ReactNode } from 'react'
+import { ToastOptions } from '@ark-ui/react/toast'
 
-export type NotifyOptionsType =
-  | 'info'
-  | 'info-subtle'
-  | 'success'
-  | 'success-subtle'
-  | 'warning'
-  | 'warning-subtle'
-  | 'error'
-  | 'error-subtle'
-  | 'loading'
-  | 'loading-subtle'
+export type NotifyOptionsType = ToastOptions['type']
 
-export interface NotifyOptions {
-  /**
-   * The palette of the notification.
-   * @default 'info'
-   */
-  palette?: NotifyOptionsType
-  /**
-   * The heading of the notification.
-   */
-  heading: string
-  /**
-   * The description of the notification.
-   */
-  description?: ReactNode
-  /**
-   * The action to take when the notification is closed
-   */
-  action?: {
-    label: string
-    onClick: () => void
-  }
+export interface NotifyOptions extends ToastOptions {
+  usage?: 'subtle' | 'default'
 }

--- a/packages/react/src/components/notifications/types.ts
+++ b/packages/react/src/components/notifications/types.ts
@@ -1,4 +1,3 @@
-import type { CreateToasterReturn } from '@ark-ui/react/toast'
 import type { ReactNode } from 'react'
 
 export type NotifyOptionsType =
@@ -34,11 +33,4 @@ export interface NotifyOptions {
     label: string
     onClick: () => void
   }
-}
-
-export type UseNotificationCenterReturn = CreateToasterReturn & {
-  /**
-   * @deprecated use `create` instead
-   */
-  notify: (options: NotifyOptions) => void
 }

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -84,6 +84,8 @@ export {
   TagsInputRootProvider,
   useTimer,
   TimerRootProvider,
+  createToaster,
+  Toaster,
   useToggle,
   useToggleContext,
   useToggleGroup,


### PR DESCRIPTION
engine update

# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #2323 
<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
Removes deprecated `useNotificationCenter` API after multi-versioned warning shipped

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
