### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: 🧾 Code Checks
 
 on: [merge_group, pull_request]
 
+permissions:
+  contents: read
+
 env:
   CI: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/omnifed/cerberus/security/code-scanning/7](https://github.com/omnifed/cerberus/security/code-scanning/7)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/checks.yml` so all jobs inherit minimal required scope.  
For this workflow, the best single fix is:

- Add:
  - `permissions:`
  - `  contents: read`

Place it after the `on:` trigger section (before `env:` is ideal). This preserves current functionality while ensuring `GITHUB_TOKEN` is constrained for all jobs unless overridden later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
