### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,9 @@ name: 💅 Lint Checks
 
 on: [merge_group, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint-ox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/omnifed/cerberus/security/code-scanning/4](https://github.com/omnifed/cerberus/security/code-scanning/4)

Add an explicit top-level `permissions` block to `.github/workflows/linting.yml` so all jobs inherit least-privilege access unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout`)

Best single fix without changing behavior: insert:

```yml
permissions:
  contents: read
```

directly after the `on:` block (before `jobs:`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
