### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-figma.yml
+++ b/.github/workflows/publish-figma.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CI: true
   FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}

--- a/.github/workflows/publish-figma.yml
+++ b/.github/workflows/publish-figma.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   CI: true

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "bun": ">=1.2.16",
     "node": ">=24.0.0"
   },
-  "packageManager": "pnpm@11.5.1"
+  "packageManager": "pnpm@11.8.0"
 }


### PR DESCRIPTION
Potential fix for [https://github.com/omnifed/cerberus/security/code-scanning/3](https://github.com/omnifed/cerberus/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/publish-figma.yml` at the workflow root (top-level), so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` while preventing unnecessary write scopes for `GITHUB_TOKEN`. No additional imports, methods, or definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
