### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/docs/app/components/code-preview/helpers.ts
+++ b/docs/app/components/code-preview/helpers.ts
@@ -2,7 +2,7 @@
 
 import { getShikiOptions } from '@/lib/shiki'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { ReactNode } from 'react'
 import { codeToHtml } from 'shiki'
 
@@ -25,10 +25,14 @@ export async function getExampleCode(
   const basePath = _getBasePath(context)
   const examplePath = _getExamplePath(data)
 
-  const content = await readFile(
-    join(process.cwd(), basePath, examplePath),
-    'utf-8',
-  ).catch(() => 'Example not found')
+  const safeRoot = resolve(process.cwd(), `.${basePath}`)
+  const resolvedPath = resolve(safeRoot, examplePath)
+  const rootToFile = relative(safeRoot, resolvedPath)
+  if (rootToFile.startsWith('..') || rootToFile === '' || rootToFile.includes('..\\')) {
+    return { code: fallback, preview: null, rawContent: '', fallback: true }
+  }
+
+  const content = await readFile(resolvedPath, 'utf-8').catch(() => 'Example not found')
   const formattedContent = content.replaceAll('@cerberus-design', '@cerberus')
 
   const code = await codeToHtml(formattedContent, getShikiOptions('tsx'))
@@ -59,7 +63,10 @@ interface ExampleData {
 }
 
 function _getExampleData(id: string): ExampleData {
-  const [el, demo] = id?.split('.') ?? ['', '']
+  const [elRaw, demoRaw] = id?.split('.') ?? ['', '']
+  const segmentPattern = /^[a-zA-Z0-9-]+$/
+  const el = segmentPattern.test(elRaw) ? elRaw : ''
+  const demo = segmentPattern.test(demoRaw) ? demoRaw : ''
   return {
     el,
     demo,

--- a/docs/app/components/code-preview/helpers.ts
+++ b/docs/app/components/code-preview/helpers.ts
@@ -2,7 +2,7 @@
 
 import { getShikiOptions } from '@/lib/shiki'
 import { readFile } from 'node:fs/promises'
-import { join, relative, resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 import { ReactNode } from 'react'
 import { codeToHtml } from 'shiki'
 
@@ -18,8 +18,7 @@ export async function getExampleCode(
   fallback?: ReactNode,
   context?: 'components' | 'data-grid',
 ): Promise<ExampleCodeReturn> {
-  if (!id)
-    return { code: fallback, preview: null, rawContent: '', fallback: true }
+  if (!id) return { code: fallback, preview: null, rawContent: '', fallback: true }
 
   const data = _getExampleData(id)
   const basePath = _getBasePath(context)


### PR DESCRIPTION
Potential fix for [https://github.com/omnifed/cerberus/security/code-scanning/12](https://github.com/omnifed/cerberus/security/code-scanning/12)

To fix this safely without changing intended behavior, enforce two controls:

1. **Validate path components from `id`** (`el`, `demo`) against a strict allowlist pattern (for example letters, digits, and hyphens only), and reject anything else.
2. **Resolve and enforce root containment** before reading:
   - Build an absolute safe root (project docs directory),
   - Resolve the candidate file path against that root,
   - Ensure the resolved path stays inside the root using `relative` checks.

In `docs/app/components/code-preview/helpers.ts`:
- Update `node:path` import to include `resolve` and `relative`.
- In `getExampleCode`, compute `safeRoot`, resolve `examplePath` beneath it, and block access if resolved path escapes root.
- Add validation in `_getExampleData` so tainted `id` parts cannot contain traversal/path characters.

This addresses both variants (`id` and `context`) with one fix by validating context-derived root usage and enforcing containment regardless of input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
