### PR TITLE
2591 bug select show fouc shadow when clicking an option in the menu

### DIFF
--- a/.changeset/few-mugs-learn.md
+++ b/.changeset/few-mugs-learn.md
@@ -1,0 +1,5 @@
+---
+'@cerberus/panda-preset': patch
+---
+
+Fix select recipe to remove focus on content slot

--- a/packages/panda-preset/src/recipes/slots/select.ts
+++ b/packages/panda-preset/src/recipes/slots/select.ts
@@ -115,11 +115,7 @@ export const select: Partial<SlotRecipeConfig> = defineSlotRecipe({
       overflowY: 'auto',
       p: 'xs',
       rounded: 'md',
-      shadow: 'lg',
-      _focus: {
-        outline: 'none',
-        boxShadow: 'none',
-      },
+      shadow: 'sm',
       _open: {
         animationStyle: 'slide-fade-in',
         animationDuration: 'fast',

--- a/tests/panda-preset/recipes/slots/select.test.ts
+++ b/tests/panda-preset/recipes/slots/select.test.ts
@@ -106,11 +106,7 @@ describe('select recipe', () => {
       overflowY: 'auto',
       p: 'xs',
       rounded: 'md',
-      shadow: 'lg',
-      _focus: {
-        outline: 'none',
-        boxShadow: 'none',
-      },
+      shadow: 'sm',
       _open: {
         animationStyle: 'slide-fade-in',
         animationDuration: 'fast',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior (required)?
closes #2591

<!--
  Describe the current behavior that you are modifying, or link to a relevant issue.
  i.e. closes #issue_number
-->

## What is the new behavior (required)?
Removes `focus` condition in `select.content` slot which was causing shadow issues for paint

## Other information?

<!--
  Add screenshots/GIFs or any other information that you think might be useful.
-->
